### PR TITLE
Socket connections may not actually fill byte[]

### DIFF
--- a/src/me/christopherdavis/beanstalkc/command/AbstractCommand.java
+++ b/src/me/christopherdavis/beanstalkc/command/AbstractCommand.java
@@ -118,8 +118,15 @@ abstract class AbstractCommand<T> implements Command<T>
     protected byte[] readLength(InputStream in, int length) throws BeanstalkcException, IOException
     {
         int byt = 0;
+        
         byte[] bytes = new byte[length];
-        int read = in.read(bytes);
+
+        int offset = 0;
+        int numRead = 0;
+        while (offset < bytes.length &&
+               (numRead = in.read(bytes, offset, bytes.length - offset)) >= 0) {
+          offset += numRead;
+        }
 
         if (read < 0) {
             throw new IOException("No bytes available to read");


### PR DESCRIPTION
Because of network latency, packet size, etc. the byte[] may not be filled on a single read() call for larger message sizes.

This while loop will ensure that the full message body is read.
